### PR TITLE
Fixed flashing colouors on sprite editor frame not working

### DIFF
--- a/SpriteEditor.cs
+++ b/SpriteEditor.cs
@@ -289,6 +289,7 @@ namespace BeebSpriter
         /// </summary>
         private void SpriteEditor_FormClosing(object sender, FormClosingEventArgs e)
         {
+            timer.Stop();
             spritePanel.ForgetEditorForm();
         }
 

--- a/SpriteEditor.cs
+++ b/SpriteEditor.cs
@@ -277,9 +277,9 @@ namespace BeebSpriter
                     sprite.Palette[index] = BeebPalette.GetFlashingColour(sprite.Palette[index]);
                     colourPanels[index].BackColor = BeebPalette.GetWindowsColour(sprite.Palette[index]); ;
                 }
-                //currentColour.Invalidate();
-                //editorPanel.Invalidate();
-                //spritePanel.Panel.Invalidate();
+                currentColour.Invalidate();
+                editorPanel.Invalidate();
+                spritePanel.Panel.Invalidate();
             }
         }
 


### PR DESCRIPTION
Flashing colours on sprite editor stop working on alternate openings of sprite editor panel. Fixed